### PR TITLE
fix: Fix the typo of `min_items` argument if run val scripts directly

### DIFF
--- a/val.py
+++ b/val.py
@@ -160,7 +160,7 @@ def run(
                                        pad=pad,
                                        rect=rect,
                                        workers=workers,
-                                       min_items=opt.min_items,
+                                       min_items=min_items,
                                        prefix=colorstr(f'{task}: '))[0]
 
     seen = 0

--- a/val_dual.py
+++ b/val_dual.py
@@ -160,7 +160,7 @@ def run(
                                        pad=pad,
                                        rect=rect,
                                        workers=workers,
-                                       min_items=opt.min_items,
+                                       min_items=min_items,
                                        prefix=colorstr(f'{task}: '))[0]
 
     seen = 0

--- a/val_triple.py
+++ b/val_triple.py
@@ -160,7 +160,7 @@ def run(
                                        pad=pad,
                                        rect=rect,
                                        workers=workers,
-                                       min_items=opt.min_items,
+                                       min_items=min_items,
                                        prefix=colorstr(f'{task}: '))[0]
 
     seen = 0


### PR DESCRIPTION
## Problem
The typo of `min_items` will cause `NameError: name 'opt' is not defined` if we run val scripts directly.

## Solution
Change `min_items=opt.min_items` to `min_items=min_items`

Patch the fix directly from the PR (WongKinYiu/yolov9#412).
Thanks for his contribution!